### PR TITLE
Update to use PHP 8.1

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        php-version: [ '8.0', '8.1' ]
+        php-version: [ '8.1', '8.2', '8.3', '8.4' ]
         etcd-version: [ '3.3.27', '3.4.18', '3.5.2' ]
 
     name: Run tests on PHP v${{ matrix.php-version }} with etcd v${{ matrix.etcd-version }}

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     "require": {
         "aternos/etcd": "^1.5.0",
         "ext-json": "*",
-        "php": ">=8.0"
+        "php": ">=8.1"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.5"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "2ac9139b0fa0f9b6bcded905cf8f6743",
+    "content-hash": "6638397fb781842f863f26753826ea6b",
     "packages": [
         {
             "name": "aternos/etcd",
@@ -2218,13 +2218,13 @@
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": [],
+    "stability-flags": {},
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
         "ext-json": "*",
-        "php": ">=8.0"
+        "php": ">=8.1"
     },
-    "platform-dev": [],
-    "plugin-api-version": "2.3.0"
+    "platform-dev": {},
+    "plugin-api-version": "2.6.0"
 }

--- a/src/Lock.php
+++ b/src/Lock.php
@@ -8,7 +8,6 @@ use Aternos\Etcd\Exception\Status\DeadlineExceededException;
 use Aternos\Etcd\Exception\Status\InvalidResponseStatusCodeException;
 use Aternos\Etcd\Exception\Status\UnavailableException;
 use Aternos\Etcd\Exception\Status\UnknownException;
-use stdClass;
 
 /**
  * Class Lock

--- a/src/LockEntry.php
+++ b/src/LockEntry.php
@@ -61,7 +61,7 @@ class LockEntry implements \JsonSerializable
     /**
      * @return array
      */
-    public function jsonSerialize()
+    public function jsonSerialize(): mixed
     {
         return [
             "by" => $this->by,


### PR DESCRIPTION
Since PHP 8.0 has been EOL for over a year (since November 2023), I think we can upgrade the requirements from `php >= 8.0` to `php >= 8.1`. This will allow us to take advantage of the new features of PHP 8.1, update our dependencies, benefit from the performance improvements of PHP 8.1 and much more.