### PR TITLE
PHP 8.4 compatability: Make parameter types explicitly nullable

### DIFF
--- a/src/EtcdLock.php
+++ b/src/EtcdLock.php
@@ -25,7 +25,7 @@ class EtcdLock extends Lock implements LockInterface
      * @throws InvalidResponseStatusCodeException
      * @throws TooManySaveRetriesException
      */
-    public function __construct(string $key, bool $exclusive = false, int $time = 120, int $wait = 300, string $identifier = null)
+    public function __construct(string $key, bool $exclusive = false, int $time = 120, int $wait = 300, ?string $identifier = null)
     {
         parent::__construct($key);
         $this->lock($exclusive, $time, $wait, $identifier);

--- a/src/Lock.php
+++ b/src/Lock.php
@@ -263,7 +263,7 @@ class Lock
      * @throws InvalidResponseStatusCodeException
      * @throws TooManySaveRetriesException
      */
-    public function lock(bool $exclusive = false, int $time = 120, int $wait = 300, string $identifier = null): bool
+    public function lock(bool $exclusive = false, int $time = 120, int $wait = 300, ?string $identifier = null): bool
     {
         $this->exclusive = $exclusive;
         $this->time = $time;

--- a/src/LockInterface.php
+++ b/src/LockInterface.php
@@ -18,7 +18,7 @@ interface LockInterface
      * @param int $wait
      * @param string|null $identifier
      */
-    public function __construct(string $key, bool $exclusive = false, int $time = 60, int $wait = 300, string $identifier = null);
+    public function __construct(string $key, bool $exclusive = false, int $time = 60, int $wait = 300, ?string $identifier = null);
 
     /**
      * Check if is locked and returns time until lock runs out or false


### PR DESCRIPTION
In PHP 8.4 implicitly marking parameters as nullable is deprecated. This PR explicitly marks the parameters as nullable by adding a `?` to the parameter types with a default value of null (`= null`).