### PR TITLE
Add getter for lock key

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -12,14 +12,14 @@ jobs:
 
     strategy:
       matrix:
-        php-version: [ '8.1', '8.2', '8.3', '8.4' ]
-        etcd-version: [ '3.3.27', '3.4.18', '3.5.2' ]
+        php-version: [ '8.3', '8.4' ]
+        etcd-version: [ '3.4.36', '3.5.21' ]
 
     name: Run tests on PHP v${{ matrix.php-version }} with etcd v${{ matrix.etcd-version }}
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
@@ -47,7 +47,7 @@ jobs:
         run: echo "::set-output name=dir::$(composer config cache-files-dir)"
 
       - name: Restore composer from cache
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
           key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     "require": {
         "aternos/etcd": "^1.5.0",
         "ext-json": "*",
-        "php": ">=8.1"
+        "php": ">=8.3"
     },
     "require-dev": {
         "phpunit/phpunit": "^10.5"

--- a/src/Lock.php
+++ b/src/Lock.php
@@ -182,9 +182,9 @@ class Lock
     /**
      * Unique key for the resource
      *
-     * @var string|null
+     * @var string
      */
-    protected ?string $key = null;
+    protected string $key;
 
     /**
      * Timeout time of the lock
@@ -412,6 +412,15 @@ class Lock
         $this->removeLock();
 
         return true;
+    }
+
+    /**
+     * Get the unique key for the resource
+     * @return string
+     */
+    public function getKey(): string
+    {
+        return $this->key;
     }
 
     /**

--- a/test/LockTest.php
+++ b/test/LockTest.php
@@ -49,6 +49,12 @@ class LockTest extends TestCase
         $this->assertEquals("identifier", $lock->getIdentifier());
     }
 
+    public function testGetkey(): void
+    {
+        $lock = new Lock("key");
+        $this->assertEquals("key", $lock->getKey());
+    }
+
     /**
      * @throws InvalidResponseStatusCodeException
      * @throws TooManySaveRetriesException


### PR DESCRIPTION
This PR adds a getter for the key of the lock.

It also changes the type of the property to make it non-nullable. The constructor already initializes this field with a non-null value, and setting any value to this field after the constructor does nothing.

## Breaking Changes:
- Remove support for PHP 8.1 and 8.2
- Remove support for etcd 3.3
- `Lock->$string` is no longer nullable