### PR TITLE
Split etcd storage logic from Lock class

### DIFF
--- a/src/AbstractLock.php
+++ b/src/AbstractLock.php
@@ -2,6 +2,9 @@
 
 namespace Aternos\Lock;
 
+/**
+ * Abstract base class for locks that contains getters and setters for the lock properties.
+ */
 abstract class AbstractLock implements LockInterface
 {
     /**

--- a/src/Lock.php
+++ b/src/Lock.php
@@ -162,9 +162,9 @@ class Lock extends AbstractLock
      * Will be used in deleteIf and putIf requests to check
      * if there was no change in etcd while processing the lock
      *
-     * @var string|bool
+     * @var string
      */
-    protected string|bool $previousLockString = false;
+    protected ?string $previousLockString = null;
 
     /**
      * Current parsed locks
@@ -498,10 +498,10 @@ class Lock extends AbstractLock
     /**
      * Update the locks array from a JSON string
      *
-     * @param string|bool $lockString
+     * @param ?string $lockString
      * @return $this
      */
-    protected function updateFromString(string|bool $lockString): static
+    protected function updateFromString(?string $lockString): static
     {
         $this->previousLockString = $lockString;
 

--- a/src/Storage/EtcdStorage.php
+++ b/src/Storage/EtcdStorage.php
@@ -17,31 +17,37 @@ class EtcdStorage implements StorageInterface
         $this->client = $client ?? new Client();
     }
 
-    public function putIf(string $key, string $value, bool|string $previousValue, bool $returnNewValueOnFail): bool|string
+    public function putIf(string $key, string $value, ?string $previousValue, bool $returnNewValueOnFail): bool|string
     {
         try {
-            return $this->client->putIf($key, $value, $previousValue, $returnNewValueOnFail);
+            return $this->client->putIf($key, $value, $previousValue ?? false, $returnNewValueOnFail);
         } catch (UnavailableException | DeadlineExceededException | UnknownException $e) {
             throw new StorageException($e->getMessage(), $e->getCode(), $e);
         }
     }
 
-    public function deleteIf(string $key, $previousValue, bool $returnNewValueOnFail = false): bool|string
+    public function deleteIf(string $key, ?string $previousValue, bool $returnNewValueOnFail = false): bool|string
     {
         try {
-            return $this->client->deleteIf($key, $previousValue, $returnNewValueOnFail);
+            return $this->client->deleteIf($key, $previousValue ?? false, $returnNewValueOnFail);
         } catch (UnavailableException | DeadlineExceededException | UnknownException $e) {
             throw new StorageException($e->getMessage(), $e->getCode(), $e);
         }
     }
 
 
-    public function get(string $key): bool|string
+    public function get(string $key): ?string
     {
         try {
-            return $this->client->get($key);
+            $value = $this->client->get($key);
         } catch (UnavailableException | DeadlineExceededException | UnknownException $e) {
             throw new StorageException($e->getMessage(), $e->getCode(), $e);
         }
+
+        if ($value === false) {
+            return null;
+        }
+
+        return $value;
     }
 }

--- a/src/Storage/EtcdStorage.php
+++ b/src/Storage/EtcdStorage.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Aternos\Lock\Storage;
+
+use Aternos\Etcd\Client;
+use Aternos\Etcd\ClientInterface;
+use Aternos\Etcd\Exception\Status\DeadlineExceededException;
+use Aternos\Etcd\Exception\Status\UnavailableException;
+use Aternos\Etcd\Exception\Status\UnknownException;
+
+class EtcdStorage implements StorageInterface
+{
+    protected ClientInterface $client;
+
+    public function __construct(?ClientInterface $client = null)
+    {
+        $this->client = $client ?? new Client();
+    }
+
+    public function putIf(string $key, string $value, bool|string $previousValue, bool $returnNewValueOnFail): bool|string
+    {
+        try {
+            return $this->client->putIf($key, $value, $previousValue, $returnNewValueOnFail);
+        } catch (UnavailableException | DeadlineExceededException | UnknownException $e) {
+            throw new StorageException($e->getMessage(), $e->getCode(), $e);
+        }
+    }
+
+    public function deleteIf(string $key, $previousValue, bool $returnNewValueOnFail = false): bool|string
+    {
+        try {
+            return $this->client->deleteIf($key, $previousValue, $returnNewValueOnFail);
+        } catch (UnavailableException | DeadlineExceededException | UnknownException $e) {
+            throw new StorageException($e->getMessage(), $e->getCode(), $e);
+        }
+    }
+
+
+    public function get(string $key): bool|string
+    {
+        try {
+            return $this->client->get($key);
+        } catch (UnavailableException | DeadlineExceededException | UnknownException $e) {
+            throw new StorageException($e->getMessage(), $e->getCode(), $e);
+        }
+    }
+}

--- a/src/Storage/StorageException.php
+++ b/src/Storage/StorageException.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Aternos\Lock\Storage;
+
+use Exception;
+
+/**
+ * An exception thrown by a storage client. This should only be used for known exceptions as the operation will be retried by default.
+ */
+class StorageException extends Exception
+{
+
+}

--- a/src/Storage/StorageInterface.php
+++ b/src/Storage/StorageInterface.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Aternos\Lock\Storage;
+
+use Exception;
+
+/**
+ * Interface for a storage that can be used to perform etcd-like operations.
+ */
+interface StorageInterface
+{
+    /**
+     * Put `$value` if `$key` value matches `$previousValue` otherwise `$returnNewValueOnFail`
+     * @param string $key
+     * @param string $value The new value to set
+     * @param bool|string $previousValue The previous value to compare against
+     * @param bool $returnNewValueOnFail
+     * @return bool|string
+     * @throws StorageException a known, retryable error occurred
+     * @throws Exception an unknown error occurred
+     */
+    public function putIf(string $key, string $value, bool|string $previousValue, bool $returnNewValueOnFail): bool|string;
+
+    /**
+     * Delete if $key value matches $previous value otherwise $returnNewValueOnFail
+     *
+     * @param string $key
+     * @param bool|string $previousValue The previous value to compare against
+     * @param bool $returnNewValueOnFail
+     * @return bool|string
+     * @throws StorageException a known, retryable error occurred
+     * @throws Exception an unknown error occurred
+     */
+    public function deleteIf(string $key, bool|string $previousValue, bool $returnNewValueOnFail = false): bool|string;
+
+    /**
+     * Get the value of a key
+     * @param string $key
+     * @return bool|string
+     * @throws StorageException a known, retryable error occurred
+     * @throws Exception an unknown error occurred
+     */
+    public function get(string $key): bool|string;
+}

--- a/src/Storage/StorageInterface.php
+++ b/src/Storage/StorageInterface.php
@@ -10,35 +10,40 @@ use Exception;
 interface StorageInterface
 {
     /**
-     * Put `$value` if `$key` value matches `$previousValue` otherwise `$returnNewValueOnFail`
+     * Put `$value` if `$key` value matches `$previousValue` and return true. If the new value does not match and
+     * `$returnNewValueOnFail` is true return the new value, otherwise return false.
      * @param string $key
      * @param string $value The new value to set
-     * @param bool|string $previousValue The previous value to compare against
-     * @param bool $returnNewValueOnFail
-     * @return bool|string
+     * @param string|null $previousValue The previous value to compare against. If null is provided, the comparison
+     * should check that the key does not exist yet.
+     * @param bool $returnNewValueOnFail if true the new value of the key should be returned if the operation fails
+     * @return bool|string true if the operation succeeded, false if it failed and `$returnNewValueOnFail` is false,
+     * otherwise the new value of the key
      * @throws StorageException a known, retryable error occurred
      * @throws Exception an unknown error occurred
      */
-    public function putIf(string $key, string $value, bool|string $previousValue, bool $returnNewValueOnFail): bool|string;
+    public function putIf(string $key, string $value, ?string $previousValue, bool $returnNewValueOnFail): bool|string;
 
     /**
      * Delete if $key value matches $previous value otherwise $returnNewValueOnFail
      *
      * @param string $key
-     * @param bool|string $previousValue The previous value to compare against
+     * @param string|null $previousValue The previous value to compare against. If null is provided, the comparison
+     *  should check that the key does not exist yet.
      * @param bool $returnNewValueOnFail
-     * @return bool|string
+     * @return bool|string true if the operation succeeded, false if it failed and `$returnNewValueOnFail` is false,
+     * otherwise the new value of the key
      * @throws StorageException a known, retryable error occurred
      * @throws Exception an unknown error occurred
      */
-    public function deleteIf(string $key, bool|string $previousValue, bool $returnNewValueOnFail = false): bool|string;
+    public function deleteIf(string $key, ?string $previousValue, bool $returnNewValueOnFail = false): bool|string;
 
     /**
      * Get the value of a key
      * @param string $key
-     * @return bool|string
+     * @return string|null the value of the key or null if the key does not exist
      * @throws StorageException a known, retryable error occurred
      * @throws Exception an unknown error occurred
      */
-    public function get(string $key): bool|string;
+    public function get(string $key): ?string;
 }

--- a/test/LockTest.php
+++ b/test/LockTest.php
@@ -1,8 +1,8 @@
-<?php
+<?php /** @noinspection PhpUnhandledExceptionInspection */
 
 namespace Aternos\Lock\Test;
 
-use Aternos\Etcd\Exception\Status\InvalidResponseStatusCodeException;
+use Aternos\Lock\Storage\StorageException;
 use Aternos\Lock\Lock;
 use Aternos\Lock\TooManySaveRetriesException;
 use PHPUnit\Framework\TestCase;
@@ -12,12 +12,13 @@ class LockTest extends TestCase
 {
     protected function getRandomString($length = 16): string
     {
+        /** @noinspection SpellCheckingInspection */
         return substr(str_shuffle(str_repeat($x = '0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ', ceil($length / strlen($x)))), 1, $length);
     }
 
     /**
-     * @throws InvalidResponseStatusCodeException
      * @throws TooManySaveRetriesException
+     * @throws StorageException
      */
     public function testCreateLock(): void
     {
@@ -49,16 +50,12 @@ class LockTest extends TestCase
         $this->assertEquals("identifier", $lock->getIdentifier());
     }
 
-    public function testGetkey(): void
+    public function testGetKey(): void
     {
         $lock = new Lock("key");
         $this->assertEquals("key", $lock->getKey());
     }
 
-    /**
-     * @throws TooManySaveRetriesException
-     * @throws InvalidResponseStatusCodeException
-     */
     public function testBreakLock(): void
     {
         $key = $this->getRandomString();
@@ -93,10 +90,6 @@ class LockTest extends TestCase
         $breakingLock->break();
     }
 
-    /**
-     * @throws InvalidResponseStatusCodeException
-     * @throws TooManySaveRetriesException
-     */
     public function testAutoReleaseLock(): void
     {
         $key = $this->getRandomString();
@@ -111,10 +104,7 @@ class LockTest extends TestCase
         $lock->break();
     }
 
-    /**
-     * @throws TooManySaveRetriesException
-     * @throws InvalidResponseStatusCodeException
-     */
+
     public function testRefreshLock(): void
     {
         $key = $this->getRandomString();
@@ -132,10 +122,7 @@ class LockTest extends TestCase
         $this->assertFalse($lock->isLocked());
     }
 
-    /**
-     * @throws TooManySaveRetriesException
-     * @throws InvalidResponseStatusCodeException
-     */
+
     public function testRefreshLockThreshold(): void
     {
         $key = $this->getRandomString();
@@ -155,10 +142,7 @@ class LockTest extends TestCase
         $this->assertFalse($lock->isLocked());
     }
 
-    /**
-     * @throws TooManySaveRetriesException
-     * @throws InvalidResponseStatusCodeException
-     */
+
     public function testMultipleSharedLocks(): void
     {
         $key = $this->getRandomString();
@@ -194,10 +178,7 @@ class LockTest extends TestCase
         $lockC->break();
     }
 
-    /**
-     * @throws TooManySaveRetriesException
-     * @throws InvalidResponseStatusCodeException
-     */
+
     public function testExclusiveLock(): void
     {
         $key = $this->getRandomString();
@@ -212,10 +193,7 @@ class LockTest extends TestCase
         $lock->break();
     }
 
-    /**
-     * @throws TooManySaveRetriesException
-     * @throws InvalidResponseStatusCodeException
-     */
+
     public function testWaitForExclusiveLockAfterExclusiveLock(): void
     {
         $key = $this->getRandomString();
@@ -234,10 +212,7 @@ class LockTest extends TestCase
         $lockB->break();
     }
 
-    /**
-     * @throws TooManySaveRetriesException
-     * @throws InvalidResponseStatusCodeException
-     */
+
     public function testRejectSharedLockWhileExclusiveLock(): void
     {
         $key = $this->getRandomString();
@@ -255,10 +230,7 @@ class LockTest extends TestCase
         $lockB->break();
     }
 
-    /**
-     * @throws TooManySaveRetriesException
-     * @throws InvalidResponseStatusCodeException
-     */
+
     public function testRejectExclusiveLockWhileSharedLock(): void
     {
         $key = $this->getRandomString();
@@ -276,10 +248,7 @@ class LockTest extends TestCase
         $lockB->break();
     }
 
-    /**
-     * @throws TooManySaveRetriesException
-     * @throws InvalidResponseStatusCodeException
-     */
+
     public function testWaitForExclusiveLockAfterMultipleSharedLocks(): void
     {
         $key = $this->getRandomString();
@@ -311,10 +280,7 @@ class LockTest extends TestCase
         $lockD->break();
     }
 
-    /**
-     * @throws TooManySaveRetriesException
-     * @throws InvalidResponseStatusCodeException
-     */
+
     public function testLockWriteConflict(): void
     {
         $key = $this->getRandomString();
@@ -346,10 +312,7 @@ class LockTest extends TestCase
         $lockB->break();
     }
 
-    /**
-     * @throws TooManySaveRetriesException
-     * @throws InvalidResponseStatusCodeException
-     */
+
     public function testLockDeleteConflict(): void
     {
         $key = $this->getRandomString();
@@ -378,10 +341,6 @@ class LockTest extends TestCase
         $lockB->break();
     }
 
-    /**
-     * @throws InvalidResponseStatusCodeException
-     * @throws TooManySaveRetriesException
-     */
     public function testLockFunctionUsesUniqueDefaultIdentifierIfNoIdentifierParameterIsProvided(): void
     {
         # Default identifier is not set explicitly and its default value is null.
@@ -402,10 +361,6 @@ class LockTest extends TestCase
         $lock->break();
     }
 
-    /**
-     * @throws InvalidResponseStatusCodeException
-     * @throws TooManySaveRetriesException
-     */
     public function testLockFunctionUsesThePresetDefaultIdentifierIfNoIdentifierParameterIsProvided(): void
     {
         # Default identifier is set
@@ -416,10 +371,6 @@ class LockTest extends TestCase
         $lock->break();
     }
 
-    /**
-     * @throws InvalidResponseStatusCodeException
-     * @throws TooManySaveRetriesException
-     */
     public function testBreaksOnDestructWhenBreakOnDestructPropertyIsTrue(): void
     {
         # Check that break() and isLocked() are called when breakOnDestruct is set to true
@@ -435,10 +386,6 @@ class LockTest extends TestCase
         $breakingLock->__destruct();
     }
 
-    /**
-     * @throws InvalidResponseStatusCodeException
-     * @throws TooManySaveRetriesException
-     */
     public function testDoesNotBreakOnDestructWhenBreakOnDestructPropertyIsFalse(): void
     {
         # Check that break() and isLocked() are not called when breakOnDestruct is set to false
@@ -458,10 +405,6 @@ class LockTest extends TestCase
         $notBreakingLock->__destruct();
     }
 
-    /**
-     * @throws InvalidResponseStatusCodeException
-     * @throws TooManySaveRetriesException
-     */
     public function testCanLockWithSameKeyTwiceWhenIsNotExclusive(): void
     {
         $key = $this->getRandomString();
@@ -493,10 +436,6 @@ class LockTest extends TestCase
         $this->assertFalse($lockB->isLockedByOther());
     }
 
-    /**
-     * @throws InvalidResponseStatusCodeException
-     * @throws TooManySaveRetriesException
-     */
     public function testCannotLockWithSameKeyTwiceWhenIsExclusive(): void
     {
         $key = $this->getRandomString();


### PR DESCRIPTION
This PR replaces the direct dependency of the Lock class on etcd with a Storage Interface. This allows implementing other storage backends (e.g. a simple in memory backend for unit tests) without messing with the lock classes internals.