### PR TITLE
Return null if put/deleteIf fails because no previous value exists

### DIFF
--- a/src/Storage/EtcdStorage.php
+++ b/src/Storage/EtcdStorage.php
@@ -17,24 +17,35 @@ class EtcdStorage implements StorageInterface
         $this->client = $client ?? new Client();
     }
 
-    public function putIf(string $key, string $value, ?string $previousValue, bool $returnNewValueOnFail = false): bool|string
+    public function putIf(string $key, string $value, ?string $previousValue, bool $returnNewValueOnFail = false): bool|string|null
     {
         try {
-            return $this->client->putIf($key, $value, $previousValue ?? false, $returnNewValueOnFail);
+            $result = $this->client->putIf($key, $value, $previousValue ?? false, $returnNewValueOnFail);
         } catch (UnavailableException | DeadlineExceededException | UnknownException $e) {
             throw new StorageException($e->getMessage(), $e->getCode(), $e);
         }
+
+        if ($returnNewValueOnFail && $result === false) {
+            return null;
+        }
+
+        return $result;
     }
 
-    public function deleteIf(string $key, ?string $previousValue, bool $returnNewValueOnFail = false): bool|string
+    public function deleteIf(string $key, ?string $previousValue, bool $returnNewValueOnFail = false): bool|string|null
     {
         try {
-            return $this->client->deleteIf($key, $previousValue ?? false, $returnNewValueOnFail);
+            $result = $this->client->deleteIf($key, $previousValue ?? false, $returnNewValueOnFail);
         } catch (UnavailableException | DeadlineExceededException | UnknownException $e) {
             throw new StorageException($e->getMessage(), $e->getCode(), $e);
         }
-    }
 
+        if ($returnNewValueOnFail && $result === false) {
+            return null;
+        }
+
+        return $result;
+    }
 
     public function get(string $key): ?string
     {

--- a/src/Storage/StorageInterface.php
+++ b/src/Storage/StorageInterface.php
@@ -17,12 +17,12 @@ interface StorageInterface
      * @param string|null $previousValue The previous value to compare against. If null is provided, the comparison
      * should check that the key does not exist yet.
      * @param bool $returnNewValueOnFail if true the new value of the key should be returned if the operation fails
-     * @return bool|string true if the operation succeeded, false if it failed and `$returnNewValueOnFail` is false,
-     * otherwise the new value of the key
+     * @return bool|string|null true if the operation succeeded, false if it failed and `$returnNewValueOnFail` is
+     * false, otherwise the new value of the key
      * @throws StorageException a known, retryable error occurred
      * @throws Exception an unknown error occurred
      */
-    public function putIf(string $key, string $value, ?string $previousValue, bool $returnNewValueOnFail): bool|string;
+    public function putIf(string $key, string $value, ?string $previousValue, bool $returnNewValueOnFail): bool|string|null;
 
     /**
      * Delete if $key value matches $previous value otherwise $returnNewValueOnFail
@@ -31,12 +31,12 @@ interface StorageInterface
      * @param string|null $previousValue The previous value to compare against. If null is provided, the comparison
      *  should check that the key does not exist yet.
      * @param bool $returnNewValueOnFail
-     * @return bool|string true if the operation succeeded, false if it failed and `$returnNewValueOnFail` is false,
-     * otherwise the new value of the key
+     * @return bool|string|null true if the operation succeeded, false if it failed and `$returnNewValueOnFail` is
+     * false, otherwise the new value of the key
      * @throws StorageException a known, retryable error occurred
      * @throws Exception an unknown error occurred
      */
-    public function deleteIf(string $key, ?string $previousValue, bool $returnNewValueOnFail = false): bool|string;
+    public function deleteIf(string $key, ?string $previousValue, bool $returnNewValueOnFail = false): bool|string|null;
 
     /**
      * Get the value of a key


### PR DESCRIPTION
If no previous value exists for the key, but one was provided, the etcd client currently returns `false`. To match the `previousValue` parameter, it should return null instead. This PR fixes that and introduces improved tests that verify this behavior.