### PR TITLE
Add simple in memory storage for unit tests

### DIFF
--- a/src/Storage/SimpleInMemoryStorage.php
+++ b/src/Storage/SimpleInMemoryStorage.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Aternos\Lock\Storage;
+
+/**
+ * A simple in-memory storage implementation for testing purposes.
+ * This is not thread-safe and should not be used in production, but can be very useful for unit testing.
+ */
+class SimpleInMemoryStorage implements StorageInterface
+{
+    protected array $storage = [];
+
+    public function putIf(string $key, string $value, ?string $previousValue, bool $returnNewValueOnFail = false): bool|string|null
+    {
+        $realValue = $this->get($key);
+        if ($realValue === $previousValue) {
+            $this->storage[$key] = $value;
+            return true;
+        } elseif ($returnNewValueOnFail) {
+            return $realValue;
+        } else {
+            return false;
+        }
+    }
+
+    public function deleteIf(string $key, ?string $previousValue, bool $returnNewValueOnFail = false): bool|string|null
+    {
+        $realValue = $this->get($key);
+        if ($realValue === $previousValue) {
+            unset($this->storage[$key]);
+            return true;
+        } elseif ($returnNewValueOnFail) {
+            return $realValue;
+        } else {
+            return false;
+        }
+    }
+
+    public function get(string $key): ?string
+    {
+        return $this->storage[$key] ?? null;
+    }
+}

--- a/test/Storage/SimpleInMemoryStorageTest.php
+++ b/test/Storage/SimpleInMemoryStorageTest.php
@@ -1,0 +1,104 @@
+<?php
+
+namespace Aternos\Lock\Test\Storage;
+
+use Aternos\Lock\Storage\SimpleInMemoryStorage;
+use PHPUnit\Framework\Attributes\TestWith;
+use PHPUnit\Framework\TestCase;
+
+class SimpleInMemoryStorageTest extends TestCase
+{
+    protected PublicSimpleInMemoryStorage $storage;
+
+    protected function setUp(): void
+    {
+        $this->storage = new PublicSimpleInMemoryStorage();
+    }
+
+    public function testGetNull(): void
+    {
+        $this->assertNull($this->storage->get("non-existing-key"));
+    }
+
+    public function testGet(): void
+    {
+        $this->storage->getStorage()["key"] = "value";
+        $this->assertEquals("value", $this->storage->get("key"));
+    }
+
+    #[TestWith(["old"])]
+    #[TestWith([null])]
+    public function testPutIfSuccess(?string $previousValue): void
+    {
+        if ($previousValue !== null) {
+            $this->storage->getStorage()["key"] = $previousValue;
+        }
+        $this->assertTrue($this->storage->putIf("key", "new", $previousValue));
+        $this->assertEquals("new", $this->storage->get("key"));
+    }
+
+    #[TestWith(["old", null])]
+    #[TestWith([null, "old"])]
+    #[TestWith(["old", "real"])]
+    public function testPutIfFail(?string $previousValue, ?string $realValue): void
+    {
+        if ($realValue !== null) {
+            $this->storage->getStorage()["key"] = $realValue;
+        }
+        $this->assertFalse($this->storage->putIf("key", "new", $previousValue));
+        $this->assertEquals($realValue, $this->storage->get("key"));
+    }
+
+    #[TestWith(["old", null])]
+    #[TestWith([null, "old"])]
+    public function testPutIfFailValue(?string $previousValue, ?string $realValue): void
+    {
+        if ($realValue !== null) {
+            $this->storage->getStorage()["key"] = $realValue;
+        }
+        $this->assertEquals($realValue, $this->storage->putIf("key", "new", $previousValue, true));
+        $this->assertEquals($realValue, $this->storage->get("key"));
+    }
+
+    #[TestWith(["old"])]
+    #[TestWith([null])]
+    public function testDeleteIfSuccess(?string $previousValue): void
+    {
+        if ($previousValue !== null) {
+            $this->storage->getStorage()["key"] = $previousValue;
+        }
+        $this->assertTrue($this->storage->deleteIf("key", $previousValue));
+        $this->assertEquals(null, $this->storage->get("key"));
+    }
+
+    #[TestWith(["old", null])]
+    #[TestWith([null, "old"])]
+    #[TestWith(["old", "real"])]
+    public function testDeleteIfFail(?string $previousValue, ?string $realValue): void
+    {
+        if ($realValue !== null) {
+            $this->storage->getStorage()["key"] = $realValue;
+        }
+        $this->assertFalse($this->storage->deleteIf("key", $previousValue));
+        $this->assertEquals($realValue, $this->storage->get("key"));
+    }
+
+    #[TestWith(["old", null])]
+    #[TestWith([null, "old"])]
+    public function testDeleteIfFailValue(?string $previousValue, ?string $realValue): void
+    {
+        if ($realValue !== null) {
+            $this->storage->getStorage()["key"] = $realValue;
+        }
+        $this->assertEquals($realValue, $this->storage->deleteIf("key", $previousValue, true));
+        $this->assertEquals($realValue, $this->storage->get("key"));
+    }
+}
+
+class PublicSimpleInMemoryStorage extends SimpleInMemoryStorage
+{
+    public function &getStorage(): array
+    {
+        return $this->storage;
+    }
+}


### PR DESCRIPTION
This PR adds a simple implementation of the StorageInterface that stores data in memory. This is useful for running unit tests on projects that use the lock library. 